### PR TITLE
fix(auto-merge): was auto-merging on develop once checks pass, want to wait for comment

### DIFF
--- a/.bulldozer.yml
+++ b/.bulldozer.yml
@@ -3,7 +3,6 @@ version: 1
 merge:
   trigger:
     comments: ["!merge", "! merge"]
-    branch_patterns: ["develop", "develop-.*"]
 
   ignore:  
     labels: ["status: WIP"]


### PR DESCRIPTION
Bulldozer was auto merging on `develop` because of trigger with branch name, dont want that, want to make sure that someone comments `!merge` first