### PR TITLE
release-0.7

### DIFF
--- a/.github/workflows/develop-merge-verify.yaml
+++ b/.github/workflows/develop-merge-verify.yaml
@@ -1,12 +1,12 @@
 # Name should reflect when action occurs
-name: Verify PR Can Merge
+name: Develop - Verify PR Can Merge
 
 on: 
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches:
       - develop
-      # TODO: also on hotfix-X.X.X branches
+      # also on hotfix-X.X.X branches?
 
 jobs:
   # Verify that the PR Title matches expected Format

--- a/.github/workflows/hotfix-cut.yml
+++ b/.github/workflows/hotfix-cut.yml
@@ -1,7 +1,7 @@
 # TODO: creates hotfix branch off of main
 # - create branch off of main with hotfix-<major>.<minor>.X version number
 
-name: Cut Hotfix Branch
+name: Hotfix - Cut Branch
 
 # Workflow runs when manually triggered using the UI or API
 on: workflow_dispatch

--- a/.github/workflows/main-merge-verify.yaml
+++ b/.github/workflows/main-merge-verify.yaml
@@ -1,4 +1,4 @@
-name: Verify Only Release/Hotfix PRs
+name: Release/Hotfix - Verify Merge PR
 
 on: 
   pull_request:

--- a/.github/workflows/main-merge.yaml
+++ b/.github/workflows/main-merge.yaml
@@ -11,7 +11,7 @@
   # get checkout README.md
   # git commit -m "merge after release tag"
 
-name: On 'main' Merge
+name: Tag Release on Main Merge
 
 on: 
   push:

--- a/.github/workflows/main-on-merge.yaml
+++ b/.github/workflows/main-on-merge.yaml
@@ -1,5 +1,6 @@
 # TODO: on merge to main from release (and patch?) branch
 # - Create Tag (vX.X.X) on `main` branch
+# - Create Github Release
 # - upmerge develop from main (so develop has tag in history)
   # git checkout develop
   # git pull
@@ -11,7 +12,7 @@
   # get checkout README.md
   # git commit -m "merge after release tag"
 
-name: Tag Release on Main Merge
+name: Release - Tag on Merge
 
 on: 
   push:

--- a/.github/workflows/main-on-merge.yaml
+++ b/.github/workflows/main-on-merge.yaml
@@ -54,7 +54,7 @@ jobs:
         body: ${{ steps.version.outputs.log }}
   
     - name: Upmerge after release
-    - run: |
+      run: |
         git config --global user.name 'Release Cut';
         git config --global user.email 'release@cut.com';
         git checkout develop;
@@ -65,4 +65,4 @@ jobs:
         git commit -m "upmerge after $RELEASE";
         git push;
       env:
-        RELEASE: tag_name: v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}
+        RELEASE: v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}

--- a/.github/workflows/main-on-merge.yaml
+++ b/.github/workflows/main-on-merge.yaml
@@ -2,6 +2,8 @@
 # - Create Tag (vX.X.X) on `main` branch
 # - Create Github Release
 # - upmerge develop from main (so develop has tag in history)
+  # git fetch --all --tags;
+  # git pull --unshallow;
   # git checkout develop
   # git pull
   # git checkout main
@@ -28,3 +30,39 @@ jobs:
       with:
         ## This is a Personal Access Token from Admin User that allows us to bypass branch protections on develop
         token: ${{ secrets.PAT }}
+
+    - name: "Get Release Info"
+      id: version
+      run: |
+        git fetch --all --tags;
+        git pull --unshallow;
+        echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
+        echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
+        echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
+        echo "##[set-output name=log;]$(git log --format=%s $(git tag | tail -n 1)..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
+      env:
+        CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}
+        release_name: Release ${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}
+        body: ${{ steps.version.outputs.log }}
+  
+    - name: Upmerge after release
+    - run: |
+        git config --global user.name 'Release Cut';
+        git config --global user.email 'release@cut.com';
+        git checkout develop;
+        git pull;
+        git merge main;
+        git reset README.md;
+        get checkout README.md;
+        git commit -m "upmerge after $RELEASE";
+        git push;
+      env:
+        RELEASE: tag_name: v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}

--- a/.github/workflows/main-on-merge.yaml
+++ b/.github/workflows/main-on-merge.yaml
@@ -3,7 +3,6 @@
 # - Create Github Release
 # - upmerge develop from main (so develop has tag in history)
   # git fetch --all --tags;
-  # git pull --unshallow;
   # git checkout develop
   # git pull
   # git checkout main
@@ -36,7 +35,6 @@ jobs:
       id: version
       run: |
         git fetch --all --tags;
-        git pull --unshallow;
         git checkout main;
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";

--- a/.github/workflows/main-on-merge.yaml
+++ b/.github/workflows/main-on-merge.yaml
@@ -39,7 +39,7 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        echo "##[set-output name=log;]$(git log --format=%s $(git tag | tail -n 1)..HEAD | grep -i -E '^($CHANGELOG_PREFIX_LIST)')";
+        echo '##[set-output name=log;]$(git log --format=%s $(git tag | tail -n 1)..HEAD | grep -i -E "^($CHANGELOG_PREFIX_LIST)")';
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/main-on-merge.yaml
+++ b/.github/workflows/main-on-merge.yaml
@@ -39,7 +39,7 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        echo "##[set-output name=log;]$(git log --format=%s $(git tag | tail -n 1)..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
+        echo "##[set-output name=log;]$(git log --format=%s $(git tag | tail -n 1)..HEAD | grep -i -E '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/main-on-merge.yaml
+++ b/.github/workflows/main-on-merge.yaml
@@ -39,7 +39,7 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        echo "##[set-output name=log;]$(git log --format=%s $(git tag | tail -n 1)..main | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
+        echo "##[set-output name=log;]$(git log --format=%s $(git tag | tail -n 1)..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/main-on-merge.yaml
+++ b/.github/workflows/main-on-merge.yaml
@@ -36,6 +36,7 @@ jobs:
       run: |
         git fetch --all --tags;
         git pull --unshallow;
+        git checkout main;
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";

--- a/.github/workflows/main-on-merge.yaml
+++ b/.github/workflows/main-on-merge.yaml
@@ -30,6 +30,7 @@ jobs:
       with:
         ## This is a Personal Access Token from Admin User that allows us to bypass branch protections on develop
         token: ${{ secrets.PAT }}
+        fetch-depth: 0
 
     - name: "Get Release Info"
       id: version
@@ -40,7 +41,7 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        echo "##[set-output name=log;]$(git log --format=%s $(git tag | tail -n 1)..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
+        echo "##[set-output name=log;]$(git log --format=%s $(git tag | tail -n 1)..main | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -14,6 +14,7 @@ jobs:
       with:
         ## This is a Personal Access Token from Admin User that allows us to bypass branch protections on develop
         token: ${{ secrets.PAT }}
+        fetch-depth: 0
 
     # Updates the repo with all history so we can get next build number and changelog
     # NOTE: Update CHANGELOG_PREFIX_LIST to configure the lines you wan to include in the changelog (body of release PR)
@@ -26,8 +27,8 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
-        echo "##[set-output name=changelog;]$(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
+        git log --format=%s main..develop | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
+        echo "##[set-output name=changelog;]$(git log --format=%s main..develop | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -22,10 +22,10 @@ jobs:
       run: |
         git fetch --all --tags;
         git pull --unshallow;
+        git checkout develop
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
         echo "##[set-output name=changelog;]$(echo $(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)'))";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -31,6 +31,7 @@ jobs:
 
     - name: "Cut Release Branch"
       run: |
+        echo $LOG;
         ./scripts/check-release-branch.sh
         git config --global user.name 'Release Cut'
         git config --global user.email 'release@cut.com'
@@ -41,6 +42,7 @@ jobs:
       env:
         RELEASE_BRANCH: release-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
         RELEASE_VERSION: ${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}
+        LOG: ${{steps.version.outputs.log}}
 
     # Note: see https://github.com/repo-sync/pull-request#advanced-options for all options
     - name: Create Pull Request

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -3,17 +3,20 @@ name: Release - Cut Branch and PR
 # Workflow runs when manually triggered using the UI or API
 on: workflow_dispatch
  
-# This Workflow should cut a `release-*` branch from `develop`
+# This Workflow should cut a `release-*` branch from `develop` and create a PR into `main`
 jobs:
   cut-release:
     runs-on: ubuntu-latest
 
+    # TODO: Should we create step that sets "variables" for action (main branch, release commit user)
     steps: 
     - uses: actions/checkout@v2
       with:
         ## This is a Personal Access Token from Admin User that allows us to bypass branch protections on develop
         token: ${{ secrets.PAT }}
 
+    # Updates the repo with all history so we can get next build number and changelog
+    # NOTE: Update CHANGELOG_PREFIX_LIST to configure the lines you wan to include in the changelog (body of release PR)
     - name: "Get Release Info"
       id: version
       run: |
@@ -22,6 +25,9 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
+        echo "##[set-output name=log;]$(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
+      env:
+        CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 
     - name: "Cut Release Branch"
       run: |
@@ -36,6 +42,7 @@ jobs:
         RELEASE_BRANCH: release-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
         RELEASE_VERSION: ${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}
 
+    # Note: see https://github.com/repo-sync/pull-request#advanced-options for all options
     - name: Create Pull Request
       uses: repo-sync/pull-request@v2
       with:
@@ -43,7 +50,7 @@ jobs:
         source_branch: release-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
         destination_branch: "main" 
         pr_title: release-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
-        pr_body: "TODO: use short commit log" # TODO: generate changelog from short git log
+        pr_body: ${{ steps.version.outputs.log }}
         # pr_label: release
 
     # Note: This increments minor version only, for now major releases will be done manually

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -26,8 +26,8 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        git log --format=%s main..HEAD;
-        echo "##[set-output name=changelog;]$(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
+        git log --format=%s main..HEAD | grep -i -E '^($CHANGELOG_PREFIX_LIST)';
+        echo "##[set-output name=changelog;]$(git log --format=%s main..HEAD | grep -i -E '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -22,7 +22,6 @@ jobs:
       id: version
       run: |
         git fetch --all --tags;
-        git pull --unshallow;
         git checkout develop
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -25,7 +25,7 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        echo "##[set-output name=log;]$(echo $(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)'))";
+        echo "##[set-output name=changelog;]$(echo $(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)'))";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 
@@ -42,7 +42,7 @@ jobs:
       env:
         RELEASE_BRANCH: release-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
         RELEASE_VERSION: ${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}
-        LOG: ${{steps.version.outputs.log}}
+        LOG: ${{steps.version.outputs.changelog}}
 
     # Note: see https://github.com/repo-sync/pull-request#advanced-options for all options
     - name: Create Pull Request
@@ -52,7 +52,7 @@ jobs:
         source_branch: release-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
         destination_branch: "main" 
         pr_title: release-${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
-        pr_body: ${{ steps.version.outputs.log }}
+        pr_body: ${{ steps.version.outputs.changelog }}
         # pr_label: release
 
     # Note: This increments minor version only, for now major releases will be done manually

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -23,7 +23,6 @@ jobs:
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
 
-    # TODO: if $RELEASE_BRANCH exists, fail action
     - name: "Cut Release Branch"
       run: |
         ./scripts/check-release-branch.sh

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -25,6 +25,7 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
+        git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
         echo "##[set-output name=changelog;]$(echo $(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)'))";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -21,10 +21,13 @@ jobs:
     - name: "Get Release Info"
       id: version
       run: |
+        git checkout main;
+        git checkout develop
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        git log --format=%s origin/main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
+        git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
+        echo "##[set-output name=changelog;]$(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -26,8 +26,8 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        git log --format=%s main..develop | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
-        echo "##[set-output name=changelog;]$(git log --format=%s main..develop | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
+        git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
+        echo "##[set-output name=changelog;]$(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -25,7 +25,7 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        echo "##[set-output name=log;]$(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
+        echo "##[set-output name=log;]$(echo $(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)'))";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -26,7 +26,7 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
+        git log --format=%s main..HEAD;
         echo "##[set-output name=changelog;]$(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -26,8 +26,8 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        git log --format=%s main..HEAD | grep -i -E '^($CHANGELOG_PREFIX_LIST)';
-        echo "##[set-output name=changelog;]$(git log --format=%s main..HEAD | grep -i -E '^($CHANGELOG_PREFIX_LIST)')";
+        git log --format=%s main..HEAD | grep -i -E "^($CHANGELOG_PREFIX_LIST)";
+        echo '##[set-output name=changelog;]$(git log --format=%s main..HEAD | grep -i -E "^($CHANGELOG_PREFIX_LIST)")';
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -1,4 +1,4 @@
-name: Cut Release Branch and PR
+name: Release - Cut Branch and PR
 
 # Workflow runs when manually triggered using the UI or API
 on: workflow_dispatch
@@ -55,7 +55,7 @@ jobs:
       env:
         MINOR_VERSION: ${{ steps.version.outputs.minor }}
 
-    - name: "Update Next Version" # in repo files
+    - name: "Update File Versions" # in repo
       run: |
         git config --global user.name 'Release Cut'
         git config --global user.email 'release@cut.com'

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -26,8 +26,7 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        git log --format=%s main..HEAD | grep -i -E "^($CHANGELOG_PREFIX_LIST)";
-        echo '##[set-output name=changelog;]$(git log --format=%s main..HEAD | grep -i -E "^($CHANGELOG_PREFIX_LIST)")';
+        echo '##[set-output name=changelog;]$(echo $(git log --format=%s main..HEAD | grep -i -E "^($CHANGELOG_PREFIX_LIST)"))';
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -26,7 +26,8 @@ jobs:
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        echo "##[set-output name=changelog;]$(echo $(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)'))";
+        git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
+        echo "##[set-output name=changelog;]$(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -25,7 +25,6 @@ jobs:
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
         git log --format=%s origin/main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
-        echo "##[set-output name=changelog;]$(git log --format=%s origin/main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -21,13 +21,11 @@ jobs:
     - name: "Get Release Info"
       id: version
       run: |
-        git fetch --all --tags;
-        git checkout develop
         echo "##[set-output name=major;]$(./git-mkver-linux next --format '{Major}')";
         echo "##[set-output name=minor;]$(./git-mkver-linux next --format '{Minor}')";
         echo "##[set-output name=patch;]$(./git-mkver-linux next --format '{Patch}')";
-        git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
-        echo "##[set-output name=changelog;]$(git log --format=%s main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
+        git log --format=%s origin/main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)';
+        echo "##[set-output name=changelog;]$(git log --format=%s origin/main..HEAD | egrep -i -e '^($CHANGELOG_PREFIX_LIST)')";
       env:
         CHANGELOG_PREFIX_LIST: "feature|feat|fix|bugfix|bug"
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Repository containing files to test Github Actions and add/edit `.yaml` files fo
     - I think we DONT want to `squash and merge` here, so that the history stays intact
     - [x] Create Github PR
     - [ ] Create New Github Milestone?
- - [..] Release Merging
+ - [x] Release Merging
     - add git tag (vX.X.X) to `main` on merge
     - upmerge `develop` from `main` on merge to `main`
  - [ ] Hotfix Branch creation?

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-Version: 0.7-SNAPSHOT
+Version: 0.7.0
 ---
 
 # Test Github Actions

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-Version: 0.6-SNAPSHOT
+Version: 0.7-SNAPSHOT
 ---
 
 # Test Github Actions


### PR DESCRIPTION
update version for release-0.7 fix: invoke to get log fix: use double quotations fix: use grep -E test: see if grep is issue test: checkout main first test: find issue? fix: specify remote in log command fix: can't use branch to branch ref fix: remove git pull --unshallow fix: use branch to branch commit refs rather than HEAD test: see what git log is printing fix: checkout main in on-main-merge action fix: checkout develop on action start test: see what git log is outputing test: try different output name test: see what log is generating fix: attempt to fix changelog generation fix: bad syntax feature(release): Create Github Release + Generate Changelog (#24) doc: more formatting of action names and more notes doc: update notes and name of main-merge action Merge branch 'main' into develop update version after release-0.6